### PR TITLE
Add tox.ini file

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,7 @@
+- project:
+    check:
+      jobs:
+        - ansible-tox-linters
+    gate:
+      jobs:
+        - ansible-tox-linters

--- a/plugins/module_utils/network/vyos/facts/facts.py
+++ b/plugins/module_utils/network/vyos/facts/facts.py
@@ -31,11 +31,6 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.facts.legac
     Config,
 )
 
-from ansible.module_utils.network.vyos.vyos import (
-    run_commands,
-    get_capabilities,
-)
-
 
 FACT_LEGACY_SUBSETS = dict(default=Default, neighbors=Neighbors, config=Config)
 FACT_RESOURCE_SUBSETS = dict(

--- a/plugins/modules/vyos_system.py
+++ b/plugins/modules/vyos_system.py
@@ -215,7 +215,7 @@ def main():
 
     if commands:
         commit = not module.check_mode
-        response = load_config(module, commands, commit=commit)
+        load_config(module, commands, commit=commit)
         result["changed"] = True
 
     module.exit_json(**result)

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -159,7 +159,6 @@ def validate_level(value, module):
 
 def spec_to_commands(updates, module):
     commands = list()
-    state = module.params["state"]
     update_password = module.params["update_password"]
 
     def needs_update(want, have, x):

--- a/plugins/modules/vyos_vlan.py
+++ b/plugins/modules/vyos_vlan.py
@@ -153,7 +153,6 @@ def map_obj_to_commands(updates, module):
         name = w["name"]
         address = w["address"]
         state = w["state"]
-        interfaces = w["interfaces"]
 
         obj_in_have = search_obj_in_list(vlan_id, have)
 
@@ -236,7 +235,6 @@ def map_params_to_obj(module):
 
 def map_config_to_obj(module):
     objs = []
-    interfaces = list()
 
     output = run_commands(module, "show interfaces")
     lines = output[0].strip().splitlines()[3:]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+black
+flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+minversion = 1.4.2
+envlist = linters
+skipsdist = True
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+
+[testenv:linters]
+install_command = pip install {opts} {packages}
+commands =
+  black -v -l79 --check {toxinidir}
+  flake8 {posargs}
+
+[flake8]
+# E123, E125 skipped as they are invalid PEP-8.
+
+show-source = True
+ignore = E123,E125,E402,W503
+max-line-length = 160
+builtins = _
+exclude = .git,.tox


### PR DESCRIPTION
Create a tox.ini file with linters entry point for developers to run
linters locally.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>