### PR TITLE
Add bindep.txt file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,6 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc-c++ [doc test platform:rpm]
+python3-devel [test platform:rpm]
+python3 [test platform:rpm]


### PR DESCRIPTION
This adds the required distro packages needed to compile wheels.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>