### PR TITLE
Remove version from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,4 +6,3 @@ name: vyos
 namespace: vyos
 readme: README.rst
 repository: https://github.com/ansible-network/ansible_collections.vyos.vyos
-version: 0.0.1


### PR DESCRIPTION
This is no longer needed, as your collection build jobs dynamically
generate the version via git information.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>