### PR TITLE
Don't run flake8 on tests/unit/compat

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = {posargs}
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,W503
+ignore = E123,E125,E231,E402,W503
 max-line-length = 160
 builtins = _
-exclude = .git,.tox
+exclude = .git,.tox,tests/unit/compat/


### PR DESCRIPTION
Until we stop using the migration script, we cannot modify these files.
So skip flake8 for now on them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>